### PR TITLE
Filter empty rating groups

### DIFF
--- a/shared/database.py
+++ b/shared/database.py
@@ -615,7 +615,7 @@ class JuryDatabase:
     def getEventGroups(self, eventId: int) -> list[str]:
         groups = []
         with self.conn.cursor() as cursor:
-            cursor.execute(f'SELECT DISTINCT `group` FROM `attendances` WHERE eventId = {eventId} AND `hidden` = 0 ORDER BY `group`;')
+            cursor.execute(f'SELECT DISTINCT `group` FROM `attendances` WHERE eventId = {eventId} AND `hidden` = 0 AND TRIM(`group`) <> "" ORDER BY `group`;')
             for row in cursor.fetchall():
                 groups.append(row['group'])
         return groups

--- a/tests/database_test.py
+++ b/tests/database_test.py
@@ -66,6 +66,7 @@ class TestDatabase(unittest.TestCase):
         self.assertEqual(len(self.db.getAttendances(1, 4)), 2)
         self.db.addAttendance(1, 5, 'Md02')
         self.assertEqual(self.db.getAttendance(5, 1).eventCategoryName, 'Md02')
+        self.assertNotIn('', self.db.getEventGroups(1))
         self.db.setAttendanceCategory(1, 5, 'Md01')
         self.assertEqual(self.db.getAttendance(5, 1).eventCategoryName, 'Md01')
         self.assertEqual(len(self.db.getAttendances(1, 4)), 3)


### PR DESCRIPTION
### Motivation
- The Group ("Riege") dropdown showed a blank entry because attendances are inserted with an empty `group` value and the previous `getEventGroups()` query returned `''` as a distinct group which sorted to the top.
- Preventing empty or whitespace-only groups from being listed avoids confusing UI entries and unassigned-athlete artifacts in the dropdown.

### Description
- Update `getEventGroups()` in `shared/database.py` to exclude empty or whitespace-only groups by adding `AND TRIM(`group`) <> ""` to the SQL query.
- Add a regression assertion to `tests/database_test.py` to ensure `''` is not present in the result of `getEventGroups(1)` after inserting an attendance without a group.
- Changed files: `shared/database.py`, `tests/database_test.py`.

### Testing
- Ran Python syntax check with `python -m py_compile shared/database.py tests/database_test.py`, which succeeded.
- Attempted to run unit tests with `python -m pytest tests/database_test.py`, but the run was blocked due to a local MySQL connection error (`ConnectionRefusedError`), so the test suite could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197463a2008327bcdc3224c04e5f1f)