### PR TITLE
Add XLSX export endpoints and UI export buttons; refactor table builders and token validation

### DIFF
--- a/backend/api-fastapi-sqlmodel/src/main.py
+++ b/backend/api-fastapi-sqlmodel/src/main.py
@@ -31,43 +31,51 @@ def createResponse(template: str, context: dict, filename: str) -> Response:
     headers = {'Content-Disposition': f'attachment; filename="{filename}"'}
     return Response(pdf_file, headers=headers, media_type='application/pdf')
 
+def createXlsxResponse(headers: list[str], tables: list[tuple[str, list[list]]], filename: str, sheet_title: str = 'Export') -> StreamingResponse:
+    output = BytesIO()
+    wb = Workbook()
+    ws = wb.active
+    ws.title = alphaNum(sheet_title)[:31] or 'Export'
+
+    for index, (table_title, rows) in enumerate(tables):
+        if index > 0:
+            ws.append([])
+        if table_title:
+            ws.append([table_title])
+        ws.append(headers)
+        for row in rows:
+            ws.append(row)
+
+    wb.save(output)
+    output.seek(0)
+    return StreamingResponse(
+        output,
+        media_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        headers={
+            'Content-Disposition': f'attachment; filename="{filename}"'
+        },
+    )
+
 def alphaNum(text: str) -> str:
     return ''.join(x for x in text if x.isalnum())
 
-@api.get("/test")
-async def test():
-    return {"message": f"API running {datetime.now()}"}
 
-@api.get('/athletes/{token}/{userId}', response_class=HTMLResponse)
-async def athletes(userId: int, token: str):
+def validateToken(token: str) -> None:
     if r.get(token) is None:
         raise HTTPException(
             status_code=401,
             detail="unautohrized"
         )
-    db = JuryDatabase('db')
-    data = [[athlete.name(), athlete.birthFormated(), athlete.gender.name] for athlete in db.getAthletes(userId)]
+
+def buildAthletesTable(db: JuryDatabase, userId: int):
     user = db.getUser(userId)
+    data = [[athlete.name(), athlete.birthFormated(), athlete.gender.name] for athlete in db.getAthletes(userId)]
+    return user, ['name', 'birth', 'gender'], [('', data)]
 
-    context = {
-            "orientation": 'A4 portrait',
-            "title": f'Athletes of {user.team}',
-            "headers": ['name', 'birth', 'gender'],
-            "tables": [('', data)]
-        }
-    return createResponse('table.html', context, f'athletes_{alphaNum(user.team)}.pdf')
-
-@api.get('/attendances/{token}/{userId}/{eventId}', response_class=HTMLResponse)
-async def attendances(userId: int, eventId: int, token: str):
-    if r.get(token) is None:
-        raise HTTPException(
-            status_code=401,
-            detail="unautohrized"
-        )
-    db = JuryDatabase('db')
+def buildAttendancesTables(db: JuryDatabase, userId: int, eventId: int):
     event = db.getEvent(eventId)
     athleteAttendances = []
-    
+
     user = db.getUser(userId)
     if user.isHost():
         for attendance in db.getEventAttendances(event.id):
@@ -82,7 +90,7 @@ async def attendances(userId: int, eventId: int, token: str):
     athleteAttendances.sort(key=lambda t: (t[0].group, t[1], t[2].givenname))
 
     data = [[t, a.name(), a.birthFormated(), a.gender.name, b.eventCategoryName, b.group] for b, t, a in athleteAttendances]
-    
+
     # group by group
     tables = []
     if user.isHost():
@@ -94,13 +102,44 @@ async def attendances(userId: int, eventId: int, token: str):
             tables[-1][1].append(row)
     else:
         tables = [('', data)]
-    
+
+    return user, event, ['team', 'name', 'birth', 'gender', 'category', 'group'], tables
+
+@api.get("/test")
+async def test():
+    return {"message": f"API running {datetime.now()}"}
+
+@api.get('/athletes/{token}/{userId}', response_class=HTMLResponse)
+async def athletes(userId: int, token: str):
+    validateToken(token)
+    db = JuryDatabase('db')
+    user, headers, tables = buildAthletesTable(db, userId)
+
+    context = {
+            "orientation": 'A4 portrait',
+            "title": f'Athletes of {user.team}',
+            "headers": headers,
+            "tables": tables
+        }
+    return createResponse('table.html', context, f'athletes_{alphaNum(user.team)}.pdf')
+
+@api.get('/athletes_xlsx/{token}/{userId}')
+async def athletes_xlsx(userId: int, token: str):
+    validateToken(token)
+    db = JuryDatabase('db')
+    user, headers, tables = buildAthletesTable(db, userId)
+    return createXlsxResponse(headers, tables, f'athletes_{alphaNum(user.team)}.xlsx', user.team)
+
+@api.get('/attendances/{token}/{userId}/{eventId}', response_class=HTMLResponse)
+async def attendances(userId: int, eventId: int, token: str):
+    validateToken(token)
+    db = JuryDatabase('db')
+    user, event, headers, tables = buildAttendancesTables(db, userId, eventId)
+
     title = f'Attendances for {event.descr()}'
     if not user.isHost():
         title += f' of {user.team}'
-    
-    headers = ['team', 'name', 'birth', 'gender', 'category', 'group']
-    
+
     context = {
             "orientation": 'A4 portrait',
             "title": title,
@@ -108,6 +147,13 @@ async def attendances(userId: int, eventId: int, token: str):
             "tables": tables
         }
     return createResponse('table.html', context, f'attendance_{alphaNum(event.name)}_{alphaNum(user.team)}.pdf')
+
+@api.get('/attendances_xlsx/{token}/{userId}/{eventId}')
+async def attendances_xlsx(userId: int, eventId: int, token: str):
+    validateToken(token)
+    db = JuryDatabase('db')
+    user, event, headers, tables = buildAttendancesTables(db, userId, eventId)
+    return createXlsxResponse(headers, tables, f'attendance_{alphaNum(event.name)}_{alphaNum(user.team)}.xlsx', event.name)
 
 @api.get('/results/{eventId}', response_class=HTMLResponse)
 async def results(eventId: int):
@@ -132,6 +178,19 @@ async def results(eventId: int):
             "tables": tables
         }
     return createResponse('table.html', context, f'{event.name}.pdf')
+
+@api.get('/results_xlsx/{eventId}')
+async def results_xlsx(eventId: int):
+    db = JuryDatabase('db')
+    event = db.getEvent(eventId)
+    rows = []
+    for category in db.getEventCategories(eventId):
+        for rank in db.getEventCategoryRankings(eventId, category.name):
+            athlete = rank.ratings.athlete
+            user = db.getUser(athlete.userId)
+            rows.append([category.name, rank.ranking, athlete.name(), user.team, rank.ratings.sum()])
+
+    return createXlsxResponse(['category', 'rank', 'name', 'team', 'rating'], [('', rows)], f'results_{alphaNum(event.name)}.xlsx', event.name)
 
 @api.get('/ranking/{token}/{eventId}/{category}/{detail}', response_class=HTMLResponse)
 async def ranking(eventId: int, token: str, category: str, detail: int):
@@ -161,7 +220,7 @@ async def ranking(eventId: int, token: str, category: str, detail: int):
         }
     return createResponse('table.html', context, f'ranking_{category}.pdf')
 
-@api.get('/ranking_xlsx/{token}/{eventId}/{category}', response_class=HTMLResponse)
+@api.get('/ranking_xlsx/{token}/{eventId}/{category}')
 async def ranking_xlsx(eventId: int, token: str, category: str):
     if r.get(token) is None:
         raise HTTPException(

--- a/frontend/flet/src/athletes.py
+++ b/frontend/flet/src/athletes.py
@@ -60,6 +60,9 @@ class AthleteView(View):
         def printPdf(e):
             page.launch_url(f'https://{View.api()}/athletes/{self.token()}/{user.id}')
 
+        def exportXlsx(e):
+            page.launch_url(f'https://{View.api()}/athletes_xlsx/{self.token()}/{user.id}')
+
         self.table = ft.DataTable(
                 columns=[ft.DataColumn(ft.Text(self.tr.tr(h))) for h in header()],
                 rows=createRows()
@@ -72,10 +75,14 @@ class AthleteView(View):
                     icon_color=ft.Colors.BLUE_300,
                     tooltip=self.tr.tr("Add"),
                     on_click=addFunc),
-                ft.IconButton(ft.Icons.SAVE,
+                ft.IconButton(ft.Icons.PICTURE_AS_PDF,
                           icon_color=ft.Colors.BLUE_300,
                           tooltip="pdf",
-                          on_click=printPdf)]),
+                          on_click=printPdf),
+                ft.IconButton(ft.Icons.SAVE,
+                          icon_color=ft.Colors.BLUE_300,
+                          tooltip="xlsx",
+                          on_click=exportXlsx)]),
             ft.ElevatedButton("Home", on_click=lambda _: self.page.go("/")),
         ]
         

--- a/frontend/flet/src/attendance.py
+++ b/frontend/flet/src/attendance.py
@@ -26,6 +26,12 @@ class AttendanceView(View):
             eventId = self.eventCtrl.value
             page.launch_url(f'https://{View.api()}/attendances/{self.token()}/{self.user().id}/{eventId}')
 
+        def exportXlsx(e):
+            if self.eventCtrl.value is None:
+                return
+            eventId = self.eventCtrl.value
+            page.launch_url(f'https://{View.api()}/attendances_xlsx/{self.token()}/{self.user().id}/{eventId}')
+
         def createRows():
             if self.eventCtrl.value is None:
                 return []
@@ -147,10 +153,14 @@ class AttendanceView(View):
             self.eventCtrl,
             ft.Row([self.table], scroll=ft.ScrollMode.AUTO),
             ft.Row(spacing=0, controls=[
-                ft.IconButton(ft.Icons.SAVE,
+                ft.IconButton(ft.Icons.PICTURE_AS_PDF,
                           icon_color=ft.Colors.BLUE_300,
                           tooltip="pdf",
-                          on_click=printPdf)]),
+                          on_click=printPdf),
+                ft.IconButton(ft.Icons.SAVE,
+                          icon_color=ft.Colors.BLUE_300,
+                          tooltip="xlsx",
+                          on_click=exportXlsx)]),
             ft.ElevatedButton(self.tr.tr("Home"), on_click=lambda _: self.page.go("/")),
         ]
 

--- a/frontend/flet/src/home.py
+++ b/frontend/flet/src/home.py
@@ -130,7 +130,13 @@ class LoginView(View):
 
         for e in self.db.getAllEvents():
             if e.progress() == Progress.FINISHED:
-                controls.append(ft.ElevatedButton(f"{e.descr()}", on_click=lambda _,id=e.id: self.page.launch_url(f'https://{View.api()}/results/{id}')))
+                controls.append(ft.Row(
+                    controls=[
+                        ft.ElevatedButton(f"{e.descr()} PDF", on_click=lambda _,id=e.id: self.page.launch_url(f'https://{View.api()}/results/{id}')),
+                        ft.ElevatedButton("XLSX", on_click=lambda _,id=e.id: self.page.launch_url(f'https://{View.api()}/results_xlsx/{id}')),
+                    ],
+                    alignment=ft.MainAxisAlignment.CENTER,
+                ))
             if e.progress() == Progress.ACTIVE:
                 controls.append(ft.ElevatedButton(f"{e.descr()}", on_click=lambda _,id=e.id: self.page.go(f"/public/liveEvent/{id}")))
 

--- a/frontend/flet/src/ranking.py
+++ b/frontend/flet/src/ranking.py
@@ -70,7 +70,7 @@ class RankingView(View):
             if self.categoryEdit.value:
                 self.page.launch_url(f'https://{View.api()}/certificate/{self.token()}/{self.event.id}/{self.categoryEdit.value}')
 
-        def exportCsv(e):
+        def exportXlsx(e):
             if self.categoryEdit.value:
                 self.page.launch_url(f'https://{View.api()}/ranking_xlsx/{self.token()}/{self.event.id}/{self.categoryEdit.value}')
 
@@ -99,8 +99,8 @@ class RankingView(View):
             controls.append(
                 ft.IconButton(ft.Icons.SAVE,
                               icon_color=ft.Colors.BLUE_300,
-                              tooltip="csv",
-                              on_click=exportCsv))
+                              tooltip="xlsx",
+                              on_click=exportXlsx))
 
         controls.append(ft.ElevatedButton("Home", on_click=lambda _: self.page.go("/")))
 


### PR DESCRIPTION
### Motivation
- Add spreadsheet export capability alongside existing PDF reports to provide XLSX downloads for athletes, attendances, results and rankings. 
- Reduce duplicated logic for building table data and token checks by centralizing helpers. 

### Description
- Introduce `createXlsxResponse` to generate and stream XLSX files using `openpyxl`, and sanitize sheet names with `alphaNum`.
- Add backend endpoints `athletes_xlsx`, `attendances_xlsx`, and `results_xlsx`, and refactor `athletes`/`attendances` to use new helpers `validateToken`, `buildAthletesTable`, and `buildAttendancesTables`.
- Keep existing PDF routes; unify table construction so PDF endpoints reuse the same data builders and filenames use `alphaNum` for safety.
- Update frontend views to expose XLSX export actions and adjust icons/labels in `athletes.py`, `attendance.py`, `home.py`, and `ranking.py` to trigger the new XLSX endpoints.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19cfd910f883278d73446def1861f6)