### PR TITLE
Improve certificate template: A4 layout, print styles, and event-year extraction

### DIFF
--- a/backend/api-fastapi-sqlmodel/src/templates/certificate.html
+++ b/backend/api-fastapi-sqlmodel/src/templates/certificate.html
@@ -77,9 +77,6 @@
     }
 
     .certificate-footer {
-      display: flex;
-      align-items: flex-end;
-      justify-content: space-between;
       margin-top: 22mm;
       padding: 0 5mm 0 1mm;
       font-size: 12pt;
@@ -87,13 +84,21 @@
       text-align: left;
     }
 
+    .certificate-footer::after {
+      clear: both;
+      content: '';
+      display: block;
+    }
+
     .certificate-date {
+      float: left;
       margin: 0 0 4mm;
       white-space: nowrap;
     }
 
     .signature-img {
       display: block;
+      float: right;
       width: 38mm;
       height: auto;
     }

--- a/backend/api-fastapi-sqlmodel/src/templates/certificate.html
+++ b/backend/api-fastapi-sqlmodel/src/templates/certificate.html
@@ -77,6 +77,8 @@
     }
 
     .certificate-footer {
+      display: table;
+      width: 100%;
       margin-top: 22mm;
       padding: 0 5mm 0 1mm;
       font-size: 12pt;
@@ -84,21 +86,23 @@
       text-align: left;
     }
 
-    .certificate-footer::after {
-      clear: both;
-      content: '';
-      display: block;
+    .certificate-date,
+    .signature {
+      display: table-cell;
+      vertical-align: bottom;
     }
 
     .certificate-date {
-      float: left;
-      margin: 0 0 4mm;
+      margin: 0;
       white-space: nowrap;
     }
 
+    .signature {
+      text-align: right;
+    }
+
     .signature-img {
-      display: block;
-      float: right;
+      display: inline-block;
       width: 38mm;
       height: auto;
     }
@@ -119,7 +123,9 @@
     </div>
     <div class="certificate-footer">
       <p class="certificate-date">{{ event.dateFormated() }}</p>
-      <img class="signature-img" alt="Unterschrift" src="static/signature.png">
+      <div class="signature">
+        <img class="signature-img" alt="Unterschrift" src="static/signature.png">
+      </div>
     </div>
   </section>
   {% endfor %}

--- a/backend/api-fastapi-sqlmodel/src/templates/certificate.html
+++ b/backend/api-fastapi-sqlmodel/src/templates/certificate.html
@@ -9,32 +9,114 @@
 
 <body>
   <style>
+    @page {
+      size: A4 portrait;
+      margin: 0;
+    }
+
     body {
+      margin: 0;
+      color: #000;
+      font-family: Georgia, 'Times New Roman', serif;
       text-align: center;
-      font-family: Georgia, serif;
-      ;
-      margin: 20px;
+    }
+
+    .certificate {
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      min-height: 297mm;
+      padding: 88mm 31mm 40mm;
+      break-before: page;
+    }
+
+    .certificate:first-of-type {
+      break-before: auto;
+    }
+
+    .certificate-content {
+      font-style: italic;
+      font-weight: 700;
+      line-height: 1.16;
+    }
+
+    .athlete-name {
+      margin: 0 0 4mm;
+      font-size: 24pt;
+      line-height: 1.05;
+    }
+
+    .intro {
+      margin: 0;
+      font-size: 15pt;
+      line-height: 1.15;
+    }
+
+    .event-name {
+      margin: 10mm 0 0;
+      font-size: 28pt;
+      line-height: 1.08;
+    }
+
+    .event-year {
+      margin: 1mm 0 6mm;
+      font-size: 26pt;
+      line-height: 1.05;
+    }
+
+    .discipline,
+    .category,
+    .ranking {
+      margin: 0 0 4mm;
+      font-size: 18pt;
+      line-height: 1.05;
+    }
+
+    .ranking {
+      margin-bottom: 0;
+    }
+
+    .certificate-footer {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      margin-top: 22mm;
+      padding: 0 5mm 0 1mm;
+      font-size: 12pt;
+      line-height: 1;
+      text-align: left;
+    }
+
+    .certificate-date {
+      margin: 0 0 4mm;
+      white-space: nowrap;
     }
 
     .signature-img {
       display: block;
-      margin-left: auto;
-      margin-right: auto;
-      width: 200px;
+      width: 38mm;
+      height: auto;
     }
   </style>
+  {% set event_name_parts = event.name.rsplit(' ', 1) %}
+  {% set event_year = event_name_parts[1] if event_name_parts|length > 1 and event_name_parts[1].isdigit() else event.date.strftime('%Y') %}
+  {% set event_title = event_name_parts[0] if event_name_parts|length > 1 and event_name_parts[1].isdigit() else event.name %}
   {% for ranking in rankings %}
-  <h1 style="break-before: page;">{{ ranking.ratings.athlete.name() }}</h1>
-  <p>erreichte bei der</p>
-  <h2>{{ event.name }}</h2>
-  <p>
-    im Geräteturnen<br>
-    in der Klasse {{ category }}<br>
-  <h3>{{ ("den " + ranking.ranking + ". Rang") if rankingType == 0 else ("das Abzeichen in " +
-    ranking.ranking)}}</h3>
-  </p>
-  <p>{{ event.dateFormated() }}</p>
-  <img class="signature-img" alt="Unterschrift" src="static/signature.png">
+  <section class="certificate">
+    <div class="certificate-content">
+      <h1 class="athlete-name">{{ ranking.ratings.athlete.name() }}</h1>
+      <p class="intro">erreichte<br>bei der</p>
+      <h2 class="event-name">{{ event_title }}</h2>
+      <p class="event-year">{{ event_year }}</p>
+      <p class="discipline">im Geräteturnen</p>
+      <p class="category">in der Klasse&nbsp; {{ category }}</p>
+      <p class="ranking">{{ ("den&nbsp;&nbsp;&nbsp;" + ranking.ranking + ". Rang") if rankingType == 0 else ("das Abzeichen in " + ranking.ranking) }}</p>
+    </div>
+    <div class="certificate-footer">
+      <p class="certificate-date">{{ event.dateFormated() }}</p>
+      <img class="signature-img" alt="Unterschrift" src="static/signature.png">
+    </div>
+  </section>
   {% endfor %}
 </body>
 


### PR DESCRIPTION
### Motivation
- Provide a print-ready A4 certificate layout with consistent typography and spacing for each ranking entry.
- Ensure the event year is derived reliably from the event name when present and otherwise fall back to the event date.
- Make each ranking produce a separate printable section (page break) and position the signature/date consistently.

### Description
- Rewrote the certificate template `templates/certificate.html` to include print-oriented CSS (A4 size, zero margins, page breaks) and a structured layout using `.certificate`, `.certificate-content`, and `.certificate-footer` elements.
- Standardized typography and spacing, added sizes in `mm`/`pt`, and adjusted the signature image to `38mm` width for consistent scaling.
- Added Jinja logic to split `event.name` into `event_title` and `event_year` with a fallback to `event.date.strftime('%Y')` when a year is not present.
- Converted the per-ranking output into a semantic `<section class="certificate">` block so each ranking renders as a printable page with athlete name, event, discipline, category, ranking, date, and signature.

### Testing
- Ran the backend test suite with `pytest` and all tests passed.
- Executed the certificate template rendering unit test `tests/test_templates.py::test_certificate_render` which rendered sample certificates successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266c511f448327ad9d8bad6574fc16)