### PR TITLE
Add group column to rankings

### DIFF
--- a/backend/api-fastapi-sqlmodel/src/main.py
+++ b/backend/api-fastapi-sqlmodel/src/main.py
@@ -167,14 +167,14 @@ async def results(eventId: int):
         for rank in db.getEventCategoryRankings(eventId, category.name):
             athlete = rank.ratings.athlete
             user = db.getUser(athlete.userId)
-            data.append([rank.ranking, athlete.name(), user.team, rank.ratings.group, rank.ratings.sum()])
+            data.append([rank.ranking, athlete.name(), user.team, rank.ratings.sum()])
         if len(data):
             tables.append((category.name, data))
 
     context = {
             "orientation": 'A4 portrait' if detail == 0 else 'A4 landscape',
             "title": f'Rankings for {event.descr()}',
-            "headers": ['rank', 'name', 'team', 'group', 'rating'],
+            "headers": ['rank', 'name', 'team', 'rating'],
             "tables": tables
         }
     return createResponse('table.html', context, f'{event.name}.pdf')
@@ -210,12 +210,12 @@ async def ranking(eventId: int, token: str, category: str, detail: int):
             for discipline in disciplines:
                 ratingData.append(rank.ratings.prettyOrDefault(discipline.name))
         user = db.getUser(athlete.userId)
-        data.append([rank.ranking, athlete.name(), user.team, rank.ratings.group] + ratingData + [rank.ratings.sum()])
+        data.append([rank.ranking, athlete.name(), user.team] + ratingData + [rank.ratings.sum()])
 
     context = {
             "orientation": 'A4 portrait' if detail == 0 else 'A4 landscape',
             "title": f'Rankings for {event.descr()} / {category}',
-            "headers": ['rank', 'name', 'team', 'group'] + ([d.name for d in disciplines] if detail == 1 else []) + ['rating'],
+            "headers": ['rank', 'name', 'team'] + ([d.name for d in disciplines] if detail == 1 else []) + ['rating'],
             "tables": [('', data)]
         }
     return createResponse('table.html', context, f'ranking_{category}.pdf')

--- a/backend/api-fastapi-sqlmodel/src/main.py
+++ b/backend/api-fastapi-sqlmodel/src/main.py
@@ -167,14 +167,14 @@ async def results(eventId: int):
         for rank in db.getEventCategoryRankings(eventId, category.name):
             athlete = rank.ratings.athlete
             user = db.getUser(athlete.userId)
-            data.append([rank.ranking, athlete.name(), user.team, rank.ratings.sum()])
+            data.append([rank.ranking, athlete.name(), user.team, rank.ratings.group, rank.ratings.sum()])
         if len(data):
             tables.append((category.name, data))
 
     context = {
             "orientation": 'A4 portrait' if detail == 0 else 'A4 landscape',
             "title": f'Rankings for {event.descr()}',
-            "headers": ['rank', 'name', 'team', 'rating'],
+            "headers": ['rank', 'name', 'team', 'group', 'rating'],
             "tables": tables
         }
     return createResponse('table.html', context, f'{event.name}.pdf')
@@ -188,9 +188,9 @@ async def results_xlsx(eventId: int):
         for rank in db.getEventCategoryRankings(eventId, category.name):
             athlete = rank.ratings.athlete
             user = db.getUser(athlete.userId)
-            rows.append([category.name, rank.ranking, athlete.name(), user.team, rank.ratings.sum()])
+            rows.append([category.name, rank.ranking, athlete.name(), user.team, rank.ratings.group, rank.ratings.sum()])
 
-    return createXlsxResponse(['category', 'rank', 'name', 'team', 'rating'], [('', rows)], f'results_{alphaNum(event.name)}.xlsx', event.name)
+    return createXlsxResponse(['category', 'rank', 'name', 'team', 'group', 'rating'], [('', rows)], f'results_{alphaNum(event.name)}.xlsx', event.name)
 
 @api.get('/ranking/{token}/{eventId}/{category}/{detail}', response_class=HTMLResponse)
 async def ranking(eventId: int, token: str, category: str, detail: int):
@@ -210,12 +210,12 @@ async def ranking(eventId: int, token: str, category: str, detail: int):
             for discipline in disciplines:
                 ratingData.append(rank.ratings.prettyOrDefault(discipline.name))
         user = db.getUser(athlete.userId)
-        data.append([rank.ranking, athlete.name(), user.team] + ratingData + [rank.ratings.sum()])
+        data.append([rank.ranking, athlete.name(), user.team, rank.ratings.group] + ratingData + [rank.ratings.sum()])
 
     context = {
             "orientation": 'A4 portrait' if detail == 0 else 'A4 landscape',
             "title": f'Rankings for {event.descr()} / {category}',
-            "headers": ['rank', 'name', 'team'] + ([d.name for d in disciplines] if detail == 1 else []) + ['rating'],
+            "headers": ['rank', 'name', 'team', 'group'] + ([d.name for d in disciplines] if detail == 1 else []) + ['rating'],
             "tables": [('', data)]
         }
     return createResponse('table.html', context, f'ranking_{category}.pdf')
@@ -237,7 +237,7 @@ async def ranking_xlsx(eventId: int, token: str, category: str):
     ws = wb.active
     ws.title = event.name
 
-    ws.append(['category', 'rank', 'name', 'team'] + [d.name for d in disciplines] + ['rating'])
+    ws.append(['category', 'rank', 'name', 'team', 'group'] + [d.name for d in disciplines] + ['rating'])
 
     categories = [c.name for c in db.getEventCategories(eventId)] if category == 'All' else [db.getEventCategory(eventId, category).name]
     for cat in categories:
@@ -247,7 +247,7 @@ async def ranking_xlsx(eventId: int, token: str, category: str):
             for discipline in disciplines:
                 ratingData.append(rank.ratings.prettyOrDefault(discipline.name))
             user = db.getUser(athlete.userId)
-            ws.append([cat, rank.ranking, athlete.name(), user.team] + ratingData + [rank.ratings.sum()])
+            ws.append([cat, rank.ranking, athlete.name(), user.team, rank.ratings.group] + ratingData + [rank.ratings.sum()])
 
     wb.save(output)
     output.seek(0)

--- a/frontend/flet/src/ranking.py
+++ b/frontend/flet/src/ranking.py
@@ -49,6 +49,7 @@ class RankingView(View):
         cells = [
             ft.DataCell(ft.Text(index + 1)),
             ft.DataCell(ft.Text(ranking.ratings.eventCategoryName)),
+            ft.DataCell(ft.Text(ranking.ratings.group)),
             ft.DataCell(ft.Text(ranking.ranking)),
             ft.DataCell(ft.Text(ranking.ratings.athlete.name()))
             ]
@@ -58,7 +59,7 @@ class RankingView(View):
         
     def updateControls(self):
         self.table = ft.DataTable(
-                columns=[ft.DataColumn(ft.Text(h)) for h in ['', 'category', 'rank', 'name'] + [d.name for d in self.disciplines] + ['sum']],
+                columns=[ft.DataColumn(ft.Text(h)) for h in ['', 'category', 'group', 'rank', 'name'] + [d.name for d in self.disciplines] + ['sum']],
                 rows= [self.AthleteRankingAsRow(ranking, i) for i, ranking in enumerate(self.rankings)]
             )
 

--- a/shared/database.py
+++ b/shared/database.py
@@ -207,6 +207,7 @@ class AthleteRatings:
     athlete: Athlete
     eventId: int
     eventCategoryName: str
+    group: str
     ratings: dict[str, Rating]
     
     def sum(self) -> float:
@@ -690,7 +691,7 @@ class JuryDatabase:
     def getAthleteAndRatings(self, athleteId: int, eventId: int) -> AthleteRatings:
         athlete = self.getAthlete(athleteId)
         attendance = self.getAttendance(athleteId, eventId)
-        return AthleteRatings(athlete, eventId, attendance.eventCategoryName, self.getAthleteRatings(athleteId, eventId))
+        return AthleteRatings(athlete, eventId, attendance.eventCategoryName, attendance.group, self.getAthleteRatings(athleteId, eventId))
 
     def _getEventCategoryRankings(self, eventId, category: EventCategory) -> list[AthleteRanking]:
         customRanking = self.getEvent(eventId).customRanking


### PR DESCRIPTION
### Motivation
- Rankings displayed to the host must show the attendance `group` (Riege) alongside category/rank/name so hosts can see grouping information. 
- Exports and printable ranking views should include the same `group` column so PDF/XLSX outputs match the UI. 

### Description
- Add a `group` field to `AthleteRatings` and populate it from the athlete's attendance in `getAthleteAndRatings` in `shared/database.py`. 
- Update the Flet host ranking view in `frontend/flet/src/ranking.py` to add a `group` column and render `ranking.ratings.group` in each row. 
- Update backend endpoints in `backend/api-fastapi-sqlmodel/src/main.py` to include `group` in the `results`, `results_xlsx`, `ranking`, and `ranking_xlsx` outputs and adjust headers for PDF/XLSX exports. 

### Testing
- Run `python3 -m py_compile shared/database.py frontend/flet/src/ranking.py backend/api-fastapi-sqlmodel/src/main.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a359b335d048327adf0e96b61a002b3)