### PR TITLE
Handle missing attendance in live event ratings

### DIFF
--- a/frontend/flet/src/live_event.py
+++ b/frontend/flet/src/live_event.py
@@ -9,16 +9,20 @@ from datetime import datetime
 sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
 from shared.database import JuryDatabase, User, Athlete, Attendance, Event, Progress, Rating
 
+
+def _display_text(value):
+    return "" if value is None else str(value)
+
 def header():
     return ['Name', 'Team', 'Category', 'Discipline', 'Rating']
 
 def ratingAsRow(user: User, athlete: Athlete, attendance: Attendance, event: Event, rating: Rating):
     cells = [
-        ft.DataCell(ft.Text(athlete.name())),
-        ft.DataCell(ft.Text(user.team)),
-        ft.DataCell(ft.Text(attendance.eventCategoryName)),
-        ft.DataCell(ft.Text(rating.eventDisciplineName)),
-        ft.DataCell(ft.Text(rating.prettySum())),
+        ft.DataCell(ft.Text(_display_text(athlete.name() if athlete else None))),
+        ft.DataCell(ft.Text(_display_text(user.team if user else None))),
+        ft.DataCell(ft.Text(_display_text(attendance.eventCategoryName if attendance else None))),
+        ft.DataCell(ft.Text(_display_text(rating.eventDisciplineName))),
+        ft.DataCell(ft.Text(_display_text(rating.prettySum()))),
         ]
     return ft.DataRow(cells=cells)
 

--- a/tests/live_event_test.py
+++ b/tests/live_event_test.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import unittest
+from datetime import datetime
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "frontend", "flet", "src"))
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from live_event import ratingAsRow
+from shared.database import Athlete, Gender, Rating, User, Restrictions
+
+
+class TestLiveEvent(unittest.TestCase):
+    def test_rating_row_handles_missing_attendance(self):
+        athlete = Athlete(1, "Ada", "Lovelace", 2, "2010-01-01", Gender.FEMALE, 0)
+        user = User(2, "trainer", "", "", "Analytical Engines", datetime.now(), datetime.now(), Restrictions.TRAINER, False, False, "", "en")
+        rating = Rating(3, datetime.now(), athlete.id, 4, 5, "Floor", 4.0, 5.5)
+
+        row = ratingAsRow(user, athlete, None, None, rating)
+
+        self.assertEqual(row.cells[0].content.value, "Ada Lovelace")
+        self.assertEqual(row.cells[1].content.value, "Analytical Engines")
+        self.assertEqual(row.cells[2].content.value, "")
+        self.assertEqual(row.cells[3].content.value, "Floor")
+        self.assertEqual(row.cells[4].content.value, "9.50")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Prevent a crash in the live event view when an athlete's attendance (or other display data) is missing which caused an `AttributeError` on `eventCategoryName`. 
- Make the live ratings UI more robust to missing or partial data returned by the database. 
- Add a regression test to ensure the missing-attendance case remains handled.

### Description
- Add a `_display_text` helper that returns an empty string for `None` and otherwise stringifies values. 
- Update `ratingAsRow` in `frontend/flet/src/live_event.py` to use `_display_text` and guard access to `athlete`, `user`, and `attendance` fields so missing values render blank cells instead of raising. 
- Add `tests/live_event_test.py` which exercises `ratingAsRow` with a `None` attendance and asserts the rendered cell values.

### Testing
- Ran the new unit test with `python -m unittest tests.live_event_test` and it passed. 
- Verified syntax by compiling the modified files with `python -m py_compile frontend/flet/src/live_event.py tests/live_event_test.py`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b5b6e5e88327b4f6d09f44347bc1)