### PR TITLE
Fix judge login QR targets

### DIFF
--- a/backend/api-fastapi-sqlmodel/src/main.py
+++ b/backend/api-fastapi-sqlmodel/src/main.py
@@ -292,6 +292,9 @@ def get_bytes(image):
     image.save(img_byte_arr, format='png')
     return img_byte_arr.getvalue()
 
+def judge_login_url(user, target: str) -> str:
+    return f"https://{os.environ['SUBDOMAIN_JURY'] + os.environ['DOMAIN']}/autoLogin/{user.username}/{user.token}/{target}"
+
 @api.get('/qrcodes/login/{token}/{userId}/{target}', response_class=HTMLResponse)
 async def qrCodesLogin(userId: int, token: str, target: str, request: Request) ->Response:
     if r.get(token) is None:
@@ -306,7 +309,7 @@ async def qrCodesLogin(userId: int, token: str, target: str, request: Request) -
             status_code=404,
             detail="user not found"
         )
-    img = qrcode.make(f'https://{os.environ['SUBDOMAIN_JURY'] + os.environ['DOMAIN']}/autoLogin/{user.username}/{user.token}/{target}')
+    img = qrcode.make(judge_login_url(user, target))
     filename = f'login_{alphaNum(user.username)}.png'
     headers = {'Content-Disposition': f'attachment; filename="{filename}"'}
     return Response(get_bytes(img), headers=headers, media_type='application/png')
@@ -328,7 +331,7 @@ async def qrCodesLoginAllJudges(eventId: int, token: str, target: str) ->Respons
         )
     targets = []
     for judge in judges:
-        img = qrcode.make(f'https://{os.environ['SUBDOMAIN_API'] + os.environ['DOMAIN']}/qrcodes/login/{token}/{judge.id}/{target}')
+        img = qrcode.make(judge_login_url(judge, target))
         targets.append((judge.username, base64.b64encode(get_bytes(img)).decode("utf-8")))
 
     template = env.get_template('qr_login.html')


### PR DESCRIPTION
### Motivation
- QR codes produced for judges linked to an intermediate API QR endpoint instead of the direct auto-login URL, causing scans to land on a general login page rather than logging the judge in automatically.

### Description
- Add `judge_login_url(user, target: str)` helper in `backend/api-fastapi-sqlmodel/src/main.py` to produce the direct `/autoLogin/{username}/{token}/{target}` URL.
- Use `judge_login_url` in the single-judge QR endpoint (`/qrcodes/login/{token}/{userId}/{target}`) so PNG QR exports encode the direct auto-login link.
- Use `judge_login_url` when generating the judge-login PDF (`/judgelogins/{token}/{eventId}/{target}`) so embedded QR codes also point to the direct auto-login link.

### Testing
- Ran syntax checks with `python -m py_compile backend/api-fastapi-sqlmodel/src/main.py frontend/flet/src/event_judges.py`, which succeeded.
- Ran `python -m pytest tests/database_test.py`, which errored due to a missing MySQL instance on `localhost` in the test environment (connection refused).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3671664be08327a89e14a4a23d2e65)