### PR TITLE
Include detailed ratings in public event results

### DIFF
--- a/backend/api-fastapi-sqlmodel/src/main.py
+++ b/backend/api-fastapi-sqlmodel/src/main.py
@@ -161,20 +161,22 @@ async def results(eventId: int):
     event = db.getEvent(eventId)
     disciplines = db.getEventDisciplines(eventId)
     tables = []
-    detail = 0
     for category in db.getEventCategories(eventId):
         data = []
         for rank in db.getEventCategoryRankings(eventId, category.name):
             athlete = rank.ratings.athlete
+            ratingData = []
+            for discipline in disciplines:
+                ratingData.append(rank.ratings.prettyOrDefault(discipline.name))
             user = db.getUser(athlete.userId)
-            data.append([rank.ranking, athlete.name(), user.team, rank.ratings.sum()])
+            data.append([rank.ranking, athlete.name(), user.team] + ratingData + [rank.ratings.sum()])
         if len(data):
             tables.append((category.name, data))
 
     context = {
-            "orientation": 'A4 portrait' if detail == 0 else 'A4 landscape',
+            "orientation": 'A4 landscape',
             "title": f'Rankings for {event.descr()}',
-            "headers": ['rank', 'name', 'team', 'rating'],
+            "headers": ['rank', 'name', 'team'] + [d.name for d in disciplines] + ['rating'],
             "tables": tables
         }
     return createResponse('table.html', context, f'{event.name}.pdf')
@@ -183,14 +185,18 @@ async def results(eventId: int):
 async def results_xlsx(eventId: int):
     db = JuryDatabase('db')
     event = db.getEvent(eventId)
+    disciplines = db.getEventDisciplines(eventId)
     rows = []
     for category in db.getEventCategories(eventId):
         for rank in db.getEventCategoryRankings(eventId, category.name):
             athlete = rank.ratings.athlete
+            ratingData = []
+            for discipline in disciplines:
+                ratingData.append(rank.ratings.prettyOrDefault(discipline.name))
             user = db.getUser(athlete.userId)
-            rows.append([category.name, rank.ranking, athlete.name(), user.team, rank.ratings.group, rank.ratings.sum()])
+            rows.append([category.name, rank.ranking, athlete.name(), user.team, rank.ratings.group] + ratingData + [rank.ratings.sum()])
 
-    return createXlsxResponse(['category', 'rank', 'name', 'team', 'group', 'rating'], [('', rows)], f'results_{alphaNum(event.name)}.xlsx', event.name)
+    return createXlsxResponse(['category', 'rank', 'name', 'team', 'group'] + [d.name for d in disciplines] + ['rating'], [('', rows)], f'results_{alphaNum(event.name)}.xlsx', event.name)
 
 @api.get('/ranking/{token}/{eventId}/{category}/{detail}', response_class=HTMLResponse)
 async def ranking(eventId: int, token: str, category: str, detail: int):


### PR DESCRIPTION
### Motivation
- Public event exports should show every per-discipline rating (like the host/downloadable result) and use landscape layout for better readability.

### Description
- Updated the public PDF `/results/{eventId}` endpoint to fetch event disciplines and append each discipline's `prettyOrDefault` value as separate columns for every athlete, and force `"orientation": 'A4 landscape'` in the template context.
- Updated the public XLSX `/results_xlsx/{eventId}` endpoint to include the same per-discipline columns in the spreadsheet and to build matching header names from the event disciplines.
- Adjusted the response headers for the PDF and XLSX exports to include the discipline columns and removed the unused `detail` branch in the public all-event PDF path; changes are in `backend/api-fastapi-sqlmodel/src/main.py`.

### Testing
- Ran `python -m compileall backend/api-fastapi-sqlmodel/src/main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36dcf0418083279348230b05cb0428)